### PR TITLE
fixed cors errors on OPTION reqeust

### DIFF
--- a/api/src/controllers/AppController.php
+++ b/api/src/controllers/AppController.php
@@ -17,7 +17,12 @@ class AppController
     protected function getRequest($type) {
         header('Access-Control-Allow-Origin: *');
         header('Access-Control-Allow-Headers: Content-Type');
+        header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS');
         header('Content-type: application/json');
+        if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+            echo "options";
+            die();
+        }
 
         $data = file_get_contents("php://input");
 

--- a/app/src/Components/LoginComponent.js
+++ b/app/src/Components/LoginComponent.js
@@ -6,6 +6,20 @@ const LoginContent = () =>
 {
     function LoginClicked(){
         console.log("LogIn");
+
+        const data = {
+            email: "mail@mail.pl",
+            password: "1q2w3e4r"
+        }
+
+        fetch("http://localhost:8080/login", {
+            method: "POST",
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data)
+        }).then(response => response.json())
+            .then(data => console.log(data));
     }
 
     function RegisetClicked(){
@@ -28,7 +42,7 @@ const LoginContent = () =>
                     <input className="Input" type="password" />
                 </div>
                 <div className="LogRegButtons">
-                    <button className="Button">
+                    <button className="Button" onClick={LoginClicked}>
                         Login
                     </button>
                     <button className="Button">


### PR DESCRIPTION
Naprawa problemu związanego z cors errorami przy requestach z poziomu reacta to backendu.

Requesty OPTIONS były blokowane na backendzie i przeglądarka nie dostawała pozwolenia na dostanie się do backendu metodą POST. Tak najprościej mówiąc. 
Problem rozwiązany. Dodałem jeszcze do frontendu zapytanie do API po kliknięciu przycisku Login. Na razie to jest statyczne ale pokazuje jak to ma działać.