### PR TITLE
Created QuestionEditingCard that can contain different QuestionEditors based on the combo box selection inside the card

### DIFF
--- a/app/src/Components/MultipleChoiceQuestionEditor.js
+++ b/app/src/Components/MultipleChoiceQuestionEditor.js
@@ -1,0 +1,22 @@
+import '../Css/QuestionEditor.css'
+
+const MultipleChoiceQuestionEditor = () => {
+    return(
+        <div className="QuestionEditorContainer">
+            <input type="text" className="QuestionInput"></input>
+            <div className="EditedQuestionsList">
+                <div className="QuestionItem">
+                    <input type="checkbox" name="correct-answer" className="RadioButton"></input>
+                    <input type="text" className="QuestionInput"></input>
+                </div>
+                <div className="QuestionItem">
+                    <input type="checkbox" name="correct-answer" className="RadioButton"></input>
+                    <input type="text" className="QuestionInput"></input>
+                </div>
+            </div>
+            <button className="AddNewAnswerButton">Add an answer</button>
+        </div>
+    )
+}
+
+export default MultipleChoiceQuestionEditor

--- a/app/src/Components/QuestionEditingCard.js
+++ b/app/src/Components/QuestionEditingCard.js
@@ -1,0 +1,34 @@
+import '../Css/QuestionEditingCard.css'
+import RedCross from '../Graphics/Icons/RedCross';
+import SingleChoiceQuestionEditor from './SingleChoiceQuestionEditor';
+import MultipleChoiceQuestionEditor from './MultipleChoiceQuestionEditor';
+import ShortAndLongAnswerQuestionTitleInput from './ShortAndLongAnswerQuestionTitleInput';
+
+const QuestionEditingCard = () => {
+    return(
+        <div className="Card">
+            <div className="QuestionHeader">
+                <h1 className="QuestionNumber">Question 1</h1>
+                <div className="DeleteButton">
+                    <RedCross />
+                </div>
+            </div>
+            <div className="QuestionTypeField">
+                <h1 className="QuestionTypeText">Select question type</h1>
+                <select className="QuestionTypeSelector">
+                    <option value="no-selection">Select question type</option>
+                    <option value="single-choice">Single-choice question</option>
+                    <option value="multiple-choice">Multiple-choice question</option>
+                    <option value="short-answer">Short-answer question (100 char.)</option>
+                    <option value="long-answer">Long-answer qestion (500 char.)</option>
+                </select>
+            </div>
+            <h1 className="QuestionContentText">Question content:</h1>
+            <div className="QuestionEditor" id="QuestionEditor">
+                <SingleChoiceQuestionEditor />
+            </div>
+        </div>
+    )
+}
+
+export default QuestionEditingCard

--- a/app/src/Components/ShortAndLongAnswerQuestionTitleInput.js
+++ b/app/src/Components/ShortAndLongAnswerQuestionTitleInput.js
@@ -1,0 +1,9 @@
+import '../Css/QuestionEditor.css'
+
+const ShortAndLongAnswerQuestionTitleInput = () => {
+    return(
+        <input className="QuestionInput"></input>
+    )
+}
+
+export default ShortAndLongAnswerQuestionTitleInput

--- a/app/src/Components/SingleChoiceQuestionEditor.js
+++ b/app/src/Components/SingleChoiceQuestionEditor.js
@@ -1,0 +1,22 @@
+import '../Css/QuestionEditor.css'
+
+const SingleChoiceQuestionEditor = () => {
+    return(
+        <div className="QuestionEditorContainer">
+            <input type="text" className="QuestionInput"></input>
+            <div className="EditedQuestionsList">
+                <div className="QuestionItem">
+                    <input type="radio" name="correct-answer" className="RadioButton"></input>
+                    <input type="text" className="QuestionInput"></input>
+                </div>
+                <div className="QuestionItem">
+                    <input type="radio" name="correct-answer" className="RadioButton"></input>
+                    <input type="text" className="QuestionInput"></input>
+                </div>
+            </div>
+            <button className="AddNewAnswerButton">Add an answer</button>
+        </div>
+    )
+}
+
+export default SingleChoiceQuestionEditor

--- a/app/src/Css/QuestionEditingCard.css
+++ b/app/src/Css/QuestionEditingCard.css
@@ -1,0 +1,79 @@
+.Card{
+    background-color: #f8f8f8e3;
+    height: fit-content;
+    width: 100%;
+
+    padding: 32px;
+
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    flex-direction: column;
+
+    border-radius: 60px;
+    backdrop-filter: blur(6px);
+    filter: drop-shadow(10px 10px 10px #000000bd);
+
+    color: #000A16;
+}
+
+.Card > .QuestionHeader{
+    width: 100%;
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.Card > .QuestionHeader > .QuestionNumber{
+    flex: 1;
+
+    font-family: 'Adam', 'sans-serif';
+    font-size: xx-large;
+}
+
+.Card > .QuestionHeader > .DeleteButton{
+    cursor: pointer;
+}
+
+.Card > .QuestionTypeField{
+    width: 100%;
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.Card > .QuestionTypeField > .QuestionTypeText{
+    margin-right: 64px;
+    
+    font-family: 'Adam', 'sans-serif';
+    font-size: xx-large;
+}
+
+.Card > .QuestionTypeField > .QuestionTypeSelector{
+    width: 100%;
+    flex: 1;
+    font-family: 'Adam', 'sans-serif';
+    font-size: x-large;
+}
+
+.Card > .QuestionContentText{
+    font-family: 'Adam', 'sans-serif';
+    font-size: x-large;
+}
+
+.Card > .QuestionEditor{
+    width: 100%;
+}
+
+@media only screen and (max-width: 600px){
+    .Card > .QuestionTypeField > .QuestionTypeText{
+        margin-right: 0;
+    }
+
+    .Card > .QuestionTypeField{
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}

--- a/app/src/Css/QuestionEditor.css
+++ b/app/src/Css/QuestionEditor.css
@@ -1,0 +1,59 @@
+.QuestionEditorContainer{
+    width: 100%;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.QuestionInput{
+    width: 100%;
+
+    font-family: 'Adam', 'sans-serif';
+    font-size: xx-large;
+}
+
+.QuestionEditorContainer > .EditedQuestionsList{
+    width: 100%;
+
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.QuestionEditorContainer > .EditedQuestionsList > .QuestionItem{
+    width: 100%;
+    margin-top: 16px;
+
+    display: flex;
+    flex-direction: row;
+}
+
+.QuestionEditorContainer > .EditedQuestionsList > .QuestionItem > .RadioButton{
+    scale: 2;
+    margin-right: 16px;
+}
+
+.QuestionEditorContainer > .AddNewAnswerButton{
+    margin-top: 32px;
+    height: 32px;
+    cursor: pointer;
+    font-size: x-large;
+    padding-left: 32px;
+    padding-right: 32px;
+    font-family: 'Adam', 'sans-serif';
+    background-color: #f8f8f8e3;
+    border: 1px solid black;
+    border-radius: 20px;
+    color: black;
+}
+
+.QuestionEditorContainer > .AddNewAnswerButton:hover{
+    background-color: #909090e3;
+}
+
+@media only screen and (max-width: 600px){
+    .QuestionInput{
+        font-size: x-large;
+    }
+}

--- a/app/src/Graphics/Icons/RedCross.js
+++ b/app/src/Graphics/Icons/RedCross.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+const RedCross = () =>
+{
+  return (
+    <svg width="24" height="24" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0.150879" y="25.6067" width="36" height="6" rx="3" transform="rotate(-45 0.150879 25.6067)" fill="#FF5341"/>
+      <rect x="4.24268" width="36" height="6" rx="3" transform="rotate(45 4.24268 0)" fill="#FF5341"/>
+    </svg>
+    );
+}
+
+export default RedCross


### PR DESCRIPTION
Dodałem komponent `QuestionEditingCard`, na którym jest combo box z wyborem typu pytania:

![obraz](https://user-images.githubusercontent.com/70141120/168900001-75d0e0f8-c36c-491c-a2c8-06f26a39b5d3.png)
![obraz](https://user-images.githubusercontent.com/70141120/168900078-13fe00aa-9308-4d36-a6c9-e5b44ad8240b.png)

`QuestionEditingCard` ma diva `QuestionEditor`, do którego będzie można wkładać jeden z trzech typów edytorów:

- `SingleChoiceQuestionEditor` - edytor dla pytania jednorazowego wyboru:
![obraz](https://user-images.githubusercontent.com/70141120/168900835-7b198416-19da-4d33-ac5f-3950344f5f9d.png)
![obraz](https://user-images.githubusercontent.com/70141120/168900898-86d23ff8-6794-40d6-8ae1-1b5c6c76b95d.png)
- `MultipleChoiceQuestionEditor` - edytor dla pytania wielokrotnego wyboru:
![obraz](https://user-images.githubusercontent.com/70141120/168901659-1bd4ee40-0d3c-4ced-a02c-54202a992c75.png)
- `ShortAndLongAnswerQuestionTitleInput` - edytor dla treści pytań krótkiej i długiej odpowiedzi (wystarczy jeden dla dwóch typów):
![obraz](https://user-images.githubusercontent.com/70141120/168901766-24e08865-94c0-4a90-8a2f-6a5a01366ffc.png)

To są tylko widoki, brak tam jeszcze interaktywności